### PR TITLE
add require-dev in composer.json  and  set type in `CustomMySqlQueries.php`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,9 @@
         "illuminate/cache": "^6.0|^7.0|^8.0|^9.0|^10.0",
         "illuminate/database": "^6.0|^7.0|^8.0|^9.0|^10.0"
     },
+    "require-dev": {
+        "laravel/framework": "^8.0|^9.0|^10.0"
+    },
     "autoload": {
         "psr-4": {
             "Eghamat24\\DatabaseRepository\\": "src/"

--- a/src/CustomMySqlQueries.php
+++ b/src/CustomMySqlQueries.php
@@ -8,7 +8,7 @@ use Illuminate\Support\Str;
 
 trait CustomMySqlQueries
 {
-    protected $dataTypes = [
+    protected array $dataTypes = [
         'bool' => 'bool',
         'boolean' => 'bool',
         'bit' => 'string',
@@ -41,7 +41,7 @@ trait CustomMySqlQueries
         'point' => 'string',
     ];
 
-    protected $columnTypes = [
+    protected array $columnTypes = [
         'tinyint(1)' => 'bool'
     ];
 


### PR DESCRIPTION
- Added strict type to the ```CustomMySqlQueries.php``` file for improved code quality and type safety.
- Included ```laravel/framework``` as a dev requirement in the ```composer.json``` file.